### PR TITLE
Update to CMake 3.11 and remove nullptr redfinition.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 3.11)
 
 set(CMAKE_MODULE_PATH
     ${CMAKE_SOURCE_DIR}/cmake

--- a/heimdall-frontend/CMakeLists.txt
+++ b/heimdall-frontend/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 3.11)
 
 project(heimdall-frontend)
 
@@ -10,8 +10,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON) # moc files are generated in build (current) d
 
 find_package(Qt5Widgets REQUIRED)
 find_package(ZLIB REQUIRED)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 
 if(MINGW)
     set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
@@ -40,6 +38,7 @@ add_executable(heimdall-frontend WIN32
     ${HEIMDALL_FRONTEND_SOURCE_FILES}
     ${HEIMDALL_FRONTEND_FORMS}
     ${HEIMDALL_FRONTEND_RESOURCES})
+target_compile_features(heimdall-frontend PRIVATE cxx_std_11)
 
 include(LargeFiles)
 use_large_files(heimdall-frontend YES)

--- a/heimdall/CMakeLists.txt
+++ b/heimdall/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 3.11)
 
 project(heimdall)
 
@@ -10,8 +10,6 @@ find_package(libusb REQUIRED)
 
 set(LIBPIT_INCLUDE_DIRS
     ../libpit/source)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 
 if(MINGW)
     set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
@@ -43,6 +41,7 @@ set(HEIMDALL_SOURCE_FILES
 include(LargeFiles)
 use_large_files(heimdall YES)
 add_executable(heimdall ${HEIMDALL_SOURCE_FILES})
+target_compile_features(heimdall PRIVATE cxx_std_11)
 
 target_link_libraries(heimdall PRIVATE pit)
 target_link_libraries(heimdall PRIVATE ${LIBUSB_LIBRARY})

--- a/heimdall/source/Heimdall.h
+++ b/heimdall/source/Heimdall.h
@@ -54,12 +54,14 @@
 
 #endif
 
+#ifdef WIN32
 #if (!(defined _MSC_VER) || (_MSC_VER < 1700))
 
 #ifndef nullptr
 #define nullptr 0
 #endif
 
+#endif
 #endif
 
 #endif

--- a/libpit/CMakeLists.txt
+++ b/libpit/CMakeLists.txt
@@ -1,9 +1,9 @@
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 3.11)
 project(libpit)
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
 
 set(LIBPIT_SOURCE_FILES
     source/libpit.cpp)
 
 add_library(pit STATIC ${LIBPIT_SOURCE_FILES})
+
+target_compile_features(pit PRIVATE cxx_std_11)

--- a/libpit/source/libpit.h
+++ b/libpit/source/libpit.h
@@ -23,12 +23,13 @@
 
 #ifdef WIN32
 #pragma warning(disable : 4996)
-#endif
 
 #if (!(defined _MSC_VER) || (_MSC_VER < 1700))
 
 #ifndef nullptr
 #define nullptr 0
+#endif
+
 #endif
 
 #endif


### PR DESCRIPTION
The redefinition of nullptr, apparently needed for
some version of MSC was being incorrectly defined for
every non-MSC version, causing compile errors on
Linux with gcc.

Signed-off-by: Ed Beroset <beroset@ieee.org>