### PR TITLE
InitialiseProtocol: reset device before handshake

### DIFF
--- a/heimdall/source/BridgeManager.cpp
+++ b/heimdall/source/BridgeManager.cpp
@@ -399,23 +399,23 @@ bool BridgeManager::DetectDevice(void)
 	switch (usbLogLevel)
 	{
 		case UsbLogLevel::None:
-			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_NONE);
+			libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_NONE);
 			break;
 
 		case UsbLogLevel::Error:
-			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_ERROR);
+			libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_ERROR);
 			break;
 
 		case UsbLogLevel::Warning:
-			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_WARNING);
+			libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
 			break;
 
 		case UsbLogLevel::Info:
-			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_INFO);
+			libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
 			break;
 
 		case UsbLogLevel::Debug:
-			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_DEBUG);
+			libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
 			break;
 	}
 
@@ -464,23 +464,23 @@ int BridgeManager::Initialise(bool resume)
 	switch (usbLogLevel)
 	{
 		case UsbLogLevel::None:
-			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_NONE);
+			libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_NONE);
 			break;
 
 		case UsbLogLevel::Error:
-			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_ERROR);
+			libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_ERROR);
 			break;
 
 		case UsbLogLevel::Warning:
-			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_WARNING);
+			libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
 			break;
 
 		case UsbLogLevel::Info:
-			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_INFO);
+			libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
 			break;
 
 		case UsbLogLevel::Debug:
-			libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_DEBUG);
+			libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
 			break;
 	}
 	
@@ -1244,23 +1244,23 @@ void BridgeManager::SetUsbLogLevel(UsbLogLevel usbLogLevel)
 		switch (usbLogLevel)
 		{
 			case UsbLogLevel::None:
-				libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_NONE);
+				libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_NONE);
 				break;
 
 			case UsbLogLevel::Error:
-				libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_ERROR);
+				libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_ERROR);
 				break;
 
 			case UsbLogLevel::Warning:
-				libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_WARNING);
+				libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_WARNING);
 				break;
 
 			case UsbLogLevel::Info:
-				libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_INFO);
+				libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_INFO);
 				break;
 
 			case UsbLogLevel::Debug:
-				libusb_set_debug(libusbContext, LIBUSB_LOG_LEVEL_DEBUG);
+				libusb_set_option(libusbContext, LIBUSB_OPTION_LOG_LEVEL, LIBUSB_LOG_LEVEL_DEBUG);
 				break;
 		}
 	}


### PR DESCRIPTION
Heimdall fails to handshake with device on my Linux installation:
Initialising protocol...
ERROR: libusb error -7 whilst sending bulk transfer. Retrying...
ERROR: libusb error -7 whilst sending bulk transfer. Retrying...
ERROR: libusb error -7 whilst sending bulk transfer. Retrying...
ERROR: libusb error -7 whilst sending bulk transfer. Retrying...
ERROR: libusb error -7 whilst sending bulk transfer. Retrying...
ERROR: libusb error -7 whilst sending bulk transfer.
ERROR: Failed to send handshake!
ERROR: Failed to receive handshake response. Result: -7
ERROR: Protocol initialisation failed!

However, with the same USB cable, port and device, Heimdall
successfully handshake with the device on Windows via WinUSB.
This indicates handling of USB devices of host (AMD X570) on
Linux might lead to undesired results. Though, without further
testing, the interference from userspace (Ubuntu 20.04, KDE) can
not be ruled out.

Thus, this patch calls libusb_reset_device to ensure
the USB port is in a clean state before we send the data.

Fixes issues with newer devices and hosts.

Signed-off-by: Jesse Chan <jc@linux.com>